### PR TITLE
Changes needed for OSP14

### DIFF
--- a/roles/008-undercloud-setup-dns/tasks/main.yml
+++ b/roles/008-undercloud-setup-dns/tasks/main.yml
@@ -6,7 +6,7 @@
 - name: Get neutron subnet uuid
   shell: |
     . /home/stack/stackrc
-    neutron subnet-list | grep start | awk '{print $2}'
+    neutron subnet-list | grep start | grep ctlplane-subnet | awk '{print $2}'
   register: neutron_subnet_uuid
 
 - name: Setup DNS on Undercloud Neutron subnet

--- a/roles/014-undercloud-setup-container-registry/tasks/main.yml
+++ b/roles/014-undercloud-setup-container-registry/tasks/main.yml
@@ -29,6 +29,18 @@
           --set ceph_namespace={{additional_ceph_insecure_registry}}{{containers_ceph_namespace}}  \
           --set ceph_image={{containers_ceph_image}} --set ceph_tag={{containers_ceph_tag}} \
           --output-images-file /home/stack/templates/overcloud_containers.yaml
+        when: version < 14
+
+    - name: Create template to pull images to local registry
+      shell: |
+        . /home/stack/stackrc
+        openstack overcloud container image prepare \
+          --namespace {{additional_insecure_registry}}{{container_namespace}} \
+          --prefix openstack --tag {{containers_tag}} --push-destination 192.168.0.1:8787 \
+          --set ceph_namespace={{additional_ceph_insecure_registry}}{{containers_ceph_namespace}}  \
+          --set ceph_image={{containers_ceph_image}} --set ceph_tag={{containers_ceph_tag}} \
+          --output-images-file /home/stack/templates/overcloud_containers.yaml
+        when: version == 14
 
     - name: Pull images using the container_images.yaml
       shell: |
@@ -49,6 +61,17 @@
           --set ceph_image={{containers_ceph_image}} --set ceph_tag={{containers_ceph_tag}} \
           -e /usr/share/openstack-tripleo-heat-templates/environments/ceph-ansible/ceph-ansible.yaml \
           --output-env-file /home/stack/templates/docker_registry.yaml
+      when: version < 14
+
+    - name: Create template for using images from local registry
+      shell: |
+        . /home/stack/stackrc
+        openstack overcloud container image prepare --namespace 192.168.0.1:8787{{container_namespace}} \
+          --prefix openstack --tag {{containers_tag}} --set ceph_namespace=192.168.0.1:8787{{containers_ceph_namespace}} \
+          --set ceph_image={{containers_ceph_image}} --set ceph_tag={{containers_ceph_tag}} \
+          --output-env-file /home/stack/templates/docker_registry.yaml
+      when: version == 14
+
   always:
     - name: Collect Setup Container Registry Artifacts
       synchronize:

--- a/vars/data.yaml
+++ b/vars/data.yaml
@@ -215,6 +215,45 @@ deploy_hardware_specific_nic_configs:
       - src: files/microcloud/nic-configs/swift-storage-sm5039.yaml
         dest: /home/stack/templates/nic-configs/swift-storage-sm5039.yaml
   scalelab:
+    14:
+      # r620
+      - src: files/scalelab/nic-configs-13/ceph-storage-r620.yaml
+        dest: /home/stack/templates/nic-configs/ceph-storage-r620.yaml
+      - src: files/scalelab/nic-configs-13/cinder-storage-r620.yaml
+        dest: /home/stack/templates/nic-configs/cinder-storage-r620.yaml
+      - src: files/scalelab/nic-configs-13/compute-r620.yaml
+        dest: /home/stack/templates/nic-configs/compute-r620.yaml
+      - src: files/scalelab/nic-configs-13/controller-r620.yaml
+        dest: /home/stack/templates/nic-configs/controller-r620.yaml
+      - src: files/scalelab/nic-configs-13/swift-storage-r620.yaml
+        dest: /home/stack/templates/nic-configs/swift-storage-r620.yaml
+      # r630
+      - src: files/scalelab/nic-configs-13/ceph-storage-r630.yaml
+        dest: /home/stack/templates/nic-configs/ceph-storage-r630.yaml
+      - src: files/scalelab/nic-configs-13/cinder-storage-r630.yaml
+        dest: /home/stack/templates/nic-configs/cinder-storage-r630.yaml
+      - src: files/scalelab/nic-configs-13/compute-r630.yaml
+        dest: /home/stack/templates/nic-configs/compute-r630.yaml
+      - src: files/scalelab/nic-configs-13/controller-r630.yaml
+        dest: /home/stack/templates/nic-configs/controller-r630.yaml
+      - src: files/scalelab/nic-configs-13/swift-storage-r630.yaml
+        dest: /home/stack/templates/nic-configs/swift-storage-r630.yaml
+      # r730xd
+      - src: files/scalelab/nic-configs-13/ceph-storage-r730xd.yaml
+        dest: /home/stack/templates/nic-configs/ceph-storage-r730xd.yaml
+      - src: files/scalelab/nic-configs-13/swift-storage-r730xd.yaml
+        dest: /home/stack/templates/nic-configs/swift-storage-r730xd.yaml
+      # 1029p
+      - src: files/scalelab/nic-configs-13/ceph-storage-1029p.yaml
+        dest: /home/stack/templates/nic-configs/ceph-storage-1029p.yaml
+      - src: files/scalelab/nic-configs-13/cinder-storage-1029p.yaml
+        dest: /home/stack/templates/nic-configs/cinder-storage-1029p.yaml
+      - src: files/scalelab/nic-configs-13/compute-1029p.yaml
+        dest: /home/stack/templates/nic-configs/compute-1029p.yaml
+      - src: files/scalelab/nic-configs-13/controller-1029p.yaml
+        dest: /home/stack/templates/nic-configs/controller-1029p.yaml
+      - src: files/scalelab/nic-configs-13/swift-storage-1029p.yaml
+        dest: /home/stack/templates/nic-configs/swift-storage-1029p.yaml
     13:
       # r620
       - src: files/scalelab/nic-configs-13/ceph-storage-r620.yaml


### PR DESCRIPTION
Needed to add "14" to the nic-config dataset. Longer term we might want
to remove the replicated references, and just go with old/new. If the
templates ever do change.

OSP14 container prep fails to work if you pass the ceph-ansible
template. It doesn't seem to need that.