### PR TITLE
Ignore Errors

### DIFF
--- a/roles/014-undercloud-setup-container-registry/tasks/main.yml
+++ b/roles/014-undercloud-setup-container-registry/tasks/main.yml
@@ -52,6 +52,7 @@
       until: pull_images.rc == 0
       retries: 2
       delay: 10
+      ignore_errors: true
 
     - name: Create template for using images from local registry
       shell: |


### PR DESCRIPTION
Sometimes we are seeing some containers defined are not being pulled,
however they are not vital to the deployment. For example, Octavia.